### PR TITLE
Adiçao de agendamento de tweets

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,27 @@
+name: Agendamento de postagens de tweets
+on:
+  schedule:
+    # every day at 05:00:00 UTC
+    - cron: '0 5 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configura o Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Instala dependências
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Executa script python
+        env:
+          CONSUMER_KEY: ${{ secrets.CONSUMER_KEY }}
+          CONSUMER_SECRET: ${{ secrets.CONSUMER_SECRET }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET }}
+          MARIA_QUITERIA_API_URL: ${{ secrets.MARIA_QUITERIA_API_URL }}
+          MARIA_QUITERIA_API_TOKEN: ${{ secrets.MARIA_QUITERIA_API_TOKEN }}
+        run: python main.py


### PR DESCRIPTION
- Um agendamento que irá executar todos os dias às 8:00 horas da manhã (horário Feira de Santana) e postar tweet com o Diário Oficial.
- Issue #9 