### PR TITLE
Altera formato da data para o padrão brasileiro

### DIFF
--- a/diario/main.py
+++ b/diario/main.py
@@ -1,6 +1,6 @@
-import datetime
 import json
 import os
+from datetime import date, datetime
 
 import requests
 import tweepy
@@ -42,7 +42,7 @@ def create_maria_quiteria_api_token():
 
 
 def get_todays_gazette():
-    date_today = datetime.date.today().strftime("%Y-%m-%d")
+    date_today = date.today().strftime("%Y-%m-%d")
     token_maria_quiteria = create_maria_quiteria_api_token()
 
     params = {"start_date": date_today}
@@ -75,9 +75,10 @@ def read_keywords():
 
 def post_todays_gazette(gazettes: list):
     for gazette in gazettes:
+        date_br = datetime.strptime(gazette["date"], "%Y-%m-%d").strftime("%d/%m/%y")
         tweet_message = (
             f"Saiu uma nova edição do #DiárioOficial do poder {gazette['power']} "
-            f"de #FeiradeSantana ({gazette['date']} - {gazette['year_and_edition']}). "
+            f"de #FeiradeSantana ({date_br} - {gazette['year_and_edition']}). "
             f"📰\n{gazette['files'][0]['url']}"
         )
         tweet_id = tweet(tweet_message)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -198,3 +198,31 @@ def test_read_default_keywords_from_file(mocker, monkeypatch):
 
     assert mock_tweet.call_count == 2
     assert expected_tweet in mock_tweet.mock_calls[1].args[0]
+
+
+def test_date_format_is_correct(mocker):
+    mock_tweet = mocker.patch("diario.main.tweet")
+
+    gazettes = [
+        {
+            "crawled_from": "...",
+            "date": "2021-08-14",
+            "power": "legislativo",
+            "year_and_edition": "Ano xxx - Edição Nº xxx",
+            "events": [
+                {
+                    "title": "TEXT",
+                    "secretariat": "TEXT",
+                    "summary": "TEXT",
+                    "published_on": None,
+                }
+            ],
+            "files": [{"url": "..."}],
+        }
+    ]
+
+    expected_date = "14/08/21"
+
+    post_todays_gazette(gazettes)
+
+    assert expected_date in mock_tweet.mock_calls[0].args[0]


### PR DESCRIPTION
Se refere ao issue #20 

- Muda formato da data que vai no tweet de YYYY-MM-DD para DD/MM/YY.
- Adiciona teste para esse novo formato de data.
- Muda import do módulo datetime em diario.main.

Não tenho como rodar o projeto localmente mas os testes passaram e o hook do pre-commit também não reclamou. Perdão se não segui algum padrão de estilo do projeto!